### PR TITLE
[POC] macOS 平台原生适配与底层 API 优化

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "whimbox"
 version = "2.4.3"
 description = "奇想盒-AI游戏助手"
 readme = "README.md"
-requires-python = "==3.12.8"
+requires-python = ">=3.12"
 license-files = ["LICENSE"]
 authors = [
     {name = "nikkigallery"}
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS :: MacOS X",
 ]
 
 dependencies = [
@@ -32,11 +33,13 @@ dependencies = [
     "langchain-deepseek==1.0.1",
     "langchain-google-genai==4.2.2",
     "loguru==0.7.3",
-    "onnxruntime==1.19.0",
+    "onnxruntime>=1.19.0",
     "rapidocr==3.4.1",
     "psutil==7.1.0",
     "scipy==1.16.2",
-    "win10toast==0.9",
+    "win10toast==0.9; sys_platform == 'win32'",
+    "pyobjc>=10.0; sys_platform == 'darwin'",
+    "mss>=9.0",
 ]
 
 [project.scripts]

--- a/whimbox/common/cvars.py
+++ b/whimbox/common/cvars.py
@@ -76,8 +76,11 @@ ANGLE_NEGATIVE_Y = 1
 ANGLE_NEGATIVE_X = 2
 ANGLE_NEGATIVE_XY = 3
 
-# Process name
-PROCESS_NAME = 'X6Game-Win64-Shipping.exe'
+import sys
+if sys.platform == 'darwin':
+    PROCESS_NAME = 'com.infoldgames.infinitynikkien'
+else:
+    PROCESS_NAME = 'X6Game-Win64-Shipping.exe'
 
 # log
 LOG_NONE = 0

--- a/whimbox/common/handle_lib.py
+++ b/whimbox/common/handle_lib.py
@@ -1,138 +1,182 @@
+import sys
 import psutil
 import time
-import win32api
-import win32gui, win32process, win32con
 from whimbox.common.cvars import PROCESS_NAME
 from whimbox.common.logger import logger
 
-def get_hwnd_for_pid(pid):
-    hwnds = []
+if sys.platform == 'win32':
+    import win32api
+    import win32gui, win32process, win32con
 
-    def callback(hwnd, hwnds):
-        _, found_pid = win32process.GetWindowThreadProcessId(hwnd)
-        # 检查是否属于目标进程，且窗口是可见并且不是子窗口
-        if found_pid == pid and win32gui.IsWindowVisible(hwnd) and win32gui.GetParent(hwnd) == 0:
-            hwnds.append(hwnd)
-        return True
+    def get_hwnd_for_pid(pid):
+        hwnds = []
 
-    win32gui.EnumWindows(callback, hwnds)
-    if hwnds:
-        return hwnds[0]
-    else:
-        return 0
+        def callback(hwnd, hwnds):
+            _, found_pid = win32process.GetWindowThreadProcessId(hwnd)
+            # 检查是否属于目标进程，且窗口是可见并且不是子窗口
+            if found_pid == pid and win32gui.IsWindowVisible(hwnd) and win32gui.GetParent(hwnd) == 0:
+                hwnds.append(hwnd)
+            return True
 
-def _get_handle(process_name=None, pid=None):
-    """获得游戏窗口句柄"""
-    if pid is not None:
-        hwnd = get_hwnd_for_pid(pid)
-        return hwnd
-    elif process_name is not None:
-        for proc in psutil.process_iter(['pid', 'name']):
-            if proc.info['name'] == process_name:
-                pid = proc.info['pid']
-                hwnd = get_hwnd_for_pid(pid)
-                return hwnd
-        return 0
+        win32gui.EnumWindows(callback, hwnds)
+        if hwnds:
+            return hwnds[0]
+        else:
+            return 0
+
+    def _get_handle(process_name=None, pid=None):
+        """获得游戏窗口句柄"""
+        if pid is not None:
+            hwnd = get_hwnd_for_pid(pid)
+            return hwnd
+        elif process_name is not None:
+            for proc in psutil.process_iter(['pid', 'name']):
+                if proc.info['name'] == process_name:
+                    pid = proc.info['pid']
+                    hwnd = get_hwnd_for_pid(pid)
+                    return hwnd
+            return 0
+elif sys.platform == 'darwin':
+    from AppKit import NSWorkspace, NSApplicationActivateIgnoringOtherApps
+    import Quartz
+
 
 class ProcessHandler():
     def __init__(self, process_name=None, pid=None) -> None:
         self.process_name = process_name
         self.pid = pid
-        if self.process_name is not None:
-            self.handle = _get_handle(self.process_name)
-        elif self.pid is not None:
-            self.handle = _get_handle(self.pid)
+        self.handle = None
+        self.app = None
+        
+        if self.process_name is not None or self.pid is not None:
+            self.refresh_handle()
 
     def get_handle(self):
-        return self.handle
+        return self.handle if sys.platform == 'win32' else self.app
 
     def refresh_handle(self):
-        self.handle = _get_handle(self.process_name, self.pid)
+        if sys.platform == 'win32':
+            self.handle = _get_handle(self.process_name, self.pid)
+        elif sys.platform == 'darwin':
+            workspace = NSWorkspace.sharedWorkspace()
+            for app in workspace.runningApplications():
+                if app.bundleIdentifier() == self.process_name or app.localizedName() == self.process_name:
+                    self.app = app
+                    self.pid = app.processIdentifier()
+                    return
+            self.app = None
     
     def is_foreground(self):
-        return win32gui.GetForegroundWindow() == self.handle
+        if sys.platform == 'win32':
+            return win32gui.GetForegroundWindow() == self.handle
+        elif sys.platform == 'darwin':
+            workspace = NSWorkspace.sharedWorkspace()
+            front_app = workspace.frontmostApplication()
+            if front_app and self.app:
+                return front_app.processIdentifier() == self.app.processIdentifier()
+            return False
     
     def is_minimized(self):
-        return win32gui.IsIconic(self.handle)
+        if sys.platform == 'win32':
+            return win32gui.IsIconic(self.handle)
+        elif sys.platform == 'darwin':
+            return False # Not easily checking iconic on mac
 
     def set_foreground(self):
-        def _activate_window(hwnd):
-            # 先把窗口恢复到可见状态
-            if win32gui.IsIconic(hwnd):
-                win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
+        if sys.platform == 'win32':
+            def _activate_window(hwnd):
+                # 先把窗口恢复到可见状态
+                if win32gui.IsIconic(hwnd):
+                    win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
 
-            fg_hwnd = win32gui.GetForegroundWindow()
-            current_tid = win32api.GetCurrentThreadId()
-            target_tid, _ = win32process.GetWindowThreadProcessId(hwnd)
-            fg_tid = 0
-            if fg_hwnd:
-                fg_tid, _ = win32process.GetWindowThreadProcessId(fg_hwnd)
+                fg_hwnd = win32gui.GetForegroundWindow()
+                current_tid = win32api.GetCurrentThreadId()
+                target_tid, _ = win32process.GetWindowThreadProcessId(hwnd)
+                fg_tid = 0
+                if fg_hwnd:
+                    fg_tid, _ = win32process.GetWindowThreadProcessId(fg_hwnd)
 
-            attached_fg = False
-            attached_target = False
+                attached_fg = False
+                attached_target = False
 
-            def _safe_attach(src_tid, dst_tid, attach, label):
-                if not src_tid or not dst_tid or src_tid == dst_tid:
-                    return False
+                def _safe_attach(src_tid, dst_tid, attach, label):
+                    if not src_tid or not dst_tid or src_tid == dst_tid:
+                        return False
+                    try:
+                        win32process.AttachThreadInput(src_tid, dst_tid, attach)
+                        return True
+                    except Exception as exc:
+                        logger.warning(
+                            f"AttachThreadInput {label} failed: {exc}; "
+                            f"src_tid={src_tid}, dst_tid={dst_tid}, fg_hwnd={fg_hwnd}, hwnd={hwnd}"
+                        )
+                        return False
+
                 try:
-                    win32process.AttachThreadInput(src_tid, dst_tid, attach)
-                    return True
-                except Exception as exc:
-                    logger.warning(
-                        f"AttachThreadInput {label} failed: {exc}; "
-                        f"src_tid={src_tid}, dst_tid={dst_tid}, fg_hwnd={fg_hwnd}, hwnd={hwnd}"
-                    )
-                    return False
+                    attached_fg = _safe_attach(current_tid, fg_tid, True, "foreground")
+                    attached_target = _safe_attach(current_tid, target_tid, True, "target")
+
+                    # win32gui.BringWindowToTop(hwnd)
+                    win32gui.SetForegroundWindow(hwnd)
+                    # win32gui.SetActiveWindow(hwnd)
+                    # win32gui.SetFocus(hwnd)
+                finally:
+                    if attached_target:
+                        _safe_attach(current_tid, target_tid, False, "target-detach")
+                    if attached_fg:
+                        _safe_attach(current_tid, fg_tid, False, "foreground-detach")
 
             try:
-                attached_fg = _safe_attach(current_tid, fg_tid, True, "foreground")
-                attached_target = _safe_attach(current_tid, target_tid, True, "target")
-
-                # win32gui.BringWindowToTop(hwnd)
-                win32gui.SetForegroundWindow(hwnd)
-                # win32gui.SetActiveWindow(hwnd)
-                # win32gui.SetFocus(hwnd)
-            finally:
-                if attached_target:
-                    _safe_attach(current_tid, target_tid, False, "target-detach")
-                if attached_fg:
-                    _safe_attach(current_tid, fg_tid, False, "foreground-detach")
-
-        try:
-            if not self.is_alive():
-                raise Exception("游戏窗口不存在")
-            _activate_window(self.handle)
-            if self.is_foreground():
-                return
-            raise Exception("无法将游戏窗口前置")
-        except Exception as e:
-            logger.error(e)
-            raise Exception("游戏窗口前置失败")
+                if not self.is_alive():
+                    raise Exception("游戏窗口不存在")
+                _activate_window(self.handle)
+                if self.is_foreground():
+                    return
+                raise Exception("无法将游戏窗口前置")
+            except Exception as e:
+                logger.error(e)
+                raise Exception("游戏窗口前置失败")
+                
+        elif sys.platform == 'darwin':
+            try:
+                if not self.is_alive():
+                    raise Exception("游戏窗口不存在")
+                self.app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps)
+                time.sleep(0.5)
+                if self.is_foreground():
+                    return
+                raise Exception("无法将游戏窗口前置")
+            except Exception as e:
+                logger.error(e)
+                raise Exception("游戏窗口前置失败")
 
     def is_alive(self):
-        if not self.handle:
-            return False
-        # 检查窗口句柄是否仍然有效
-        if not win32gui.IsWindow(self.handle):
-            return False
-        return True
+        if sys.platform == 'win32':
+            if not self.handle:
+                return False
+            if not win32gui.IsWindow(self.handle):
+                return False
+            return True
+        elif sys.platform == 'darwin':
+            return self.app is not None and not self.app.isTerminated()
 
     def _get_process_pid(self):
         if self.pid is not None:
             return self.pid
+        
+        if sys.platform == 'win32':
+            if self.handle and win32gui.IsWindow(self.handle):
+                try:
+                    _, pid = win32process.GetWindowThreadProcessId(self.handle)
+                    if pid:
+                        return pid
+                except Exception as e:
+                    logger.warning(f"通过窗口句柄获取进程ID失败: {e}")
 
-        if self.handle and win32gui.IsWindow(self.handle):
-            try:
-                _, pid = win32process.GetWindowThreadProcessId(self.handle)
-                if pid:
-                    return pid
-            except Exception as e:
-                logger.warning(f"通过窗口句柄获取进程ID失败: {e}")
-
-        if self.process_name is not None:
-            for proc in psutil.process_iter(['pid', 'name']):
-                if proc.info['name'] == self.process_name:
-                    return proc.info['pid']
+            if self.process_name is not None:
+                for proc in psutil.process_iter(['pid', 'name']):
+                    if proc.info['name'] == self.process_name:
+                        return proc.info['pid']
 
         return None
 
@@ -149,7 +193,10 @@ class ProcessHandler():
 
         try:
             if self.is_alive():
-                win32gui.PostMessage(self.handle, win32con.WM_CLOSE, 0, 0)
+                if sys.platform == 'win32':
+                    win32gui.PostMessage(self.handle, win32con.WM_CLOSE, 0, 0)
+                elif sys.platform == 'darwin':
+                    self.app.terminate()
         except Exception as e:
             logger.error(e)
 
@@ -191,7 +238,19 @@ class ProcessHandler():
 
     def check_shape(self):
         if self.is_alive():
-            _, _, width, height = win32gui.GetClientRect(self.handle)
+            width, height = 0, 0
+            if sys.platform == 'win32':
+                _, _, width, height = win32gui.GetClientRect(self.handle)
+            elif sys.platform == 'darwin':
+                window_list = Quartz.CGWindowListCopyWindowInfo(Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements, Quartz.kCGNullWindowID)
+                for window in window_list:
+                    if window.get(Quartz.kCGWindowOwnerPID) == self.pid:
+                        bounds = window.get(Quartz.kCGWindowBounds)
+                        if bounds:
+                            width = int(bounds.get('Width', 0))
+                            height = int(bounds.get('Height', 0))
+                            break
+                            
             if width <= 0:
                 return False, 0, 0
             elif 1.55 < width/height < 1.80:

--- a/whimbox/common/handle_lib.py
+++ b/whimbox/common/handle_lib.py
@@ -70,10 +70,23 @@ class ProcessHandler():
         if sys.platform == 'win32':
             return win32gui.GetForegroundWindow() == self.handle
         elif sys.platform == 'darwin':
+            if not self.pid:
+                return False
+                
+            from AppKit import NSWorkspace
             workspace = NSWorkspace.sharedWorkspace()
             front_app = workspace.frontmostApplication()
-            if front_app and self.app:
-                return front_app.processIdentifier() == self.app.processIdentifier()
+            if front_app and front_app.processIdentifier() == self.pid:
+                return True
+                
+            import Quartz
+            window_list = Quartz.CGWindowListCopyWindowInfo(Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements, Quartz.kCGNullWindowID)
+            for window in window_list:
+                layer = window.get(Quartz.kCGWindowLayer, 0)
+                bounds = window.get(Quartz.kCGWindowBounds)
+                if layer == 0 and bounds and bounds.get('Height', 0) > 400 and bounds.get('Width', 0) > 400:
+                    # The first layer=0 large window in the list is the frontmost standard window!
+                    return window.get(Quartz.kCGWindowOwnerPID) == self.pid
             return False
     
     def is_minimized(self):
@@ -145,7 +158,20 @@ class ProcessHandler():
                 time.sleep(0.5)
                 if self.is_foreground():
                     return
-                raise Exception("无法将游戏窗口前置")
+                    
+                import subprocess
+                bundle_id = self.app.bundleIdentifier()
+                if bundle_id:
+                    subprocess.run(['osascript', '-e', f'tell application id "{bundle_id}" to activate'])
+                else:
+                    subprocess.run(['osascript', '-e', f'tell application "{self.app.localizedName()}" to activate'])
+                time.sleep(0.5)
+                if self.is_foreground():
+                    return
+                
+                front_app = NSWorkspace.sharedWorkspace().frontmostApplication()
+                front_name = front_app.localizedName() if front_app else 'None'
+                raise Exception(f"无法将游戏窗口前置，当前前置应用为: {front_name}")
             except Exception as e:
                 logger.error(e)
                 raise Exception("游戏窗口前置失败")
@@ -242,11 +268,13 @@ class ProcessHandler():
             if sys.platform == 'win32':
                 _, _, width, height = win32gui.GetClientRect(self.handle)
             elif sys.platform == 'darwin':
+                import Quartz
                 window_list = Quartz.CGWindowListCopyWindowInfo(Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements, Quartz.kCGNullWindowID)
                 for window in window_list:
                     if window.get(Quartz.kCGWindowOwnerPID) == self.pid:
+                        layer = window.get(Quartz.kCGWindowLayer, 0)
                         bounds = window.get(Quartz.kCGWindowBounds)
-                        if bounds:
+                        if layer == 0 and bounds and bounds.get('Height', 0) > 100:
                             width = int(bounds.get('Width', 0))
                             height = int(bounds.get('Height', 0))
                             break

--- a/whimbox/common/path_lib.py
+++ b/whimbox/common/path_lib.py
@@ -1,5 +1,5 @@
 import os
-import win32api, win32con
+import sys
 import configparser
 
 ROOT_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -13,20 +13,30 @@ LOG_PATH = os.path.join(os.getcwd(), 'logs')
 SCRIPT_PATH = os.path.join(os.getcwd(), 'scripts')
 PLUGINS_PATH = os.path.join(ROOT_PATH, 'plugins')
 
+if sys.platform == 'win32':
+    import win32api, win32con
+
 def find_game_launcher_folder():
+    if sys.platform == 'darwin':
+        return "/Applications/Infinity Nikki.app"
+
     # HKEY_CURRENT_USER\Software\InfinityNikki Launcher
     path = ""
-    key = 'Software\\InfinityNikki Launcher'
-    try:
-        key = win32api.RegOpenKey(win32con.HKEY_CURRENT_USER, key, 0, win32con.KEY_READ)
-        path, _ = win32api.RegQueryValueEx(key, "")  # 读取默认值
-        win32api.RegCloseKey(key)
-    except Exception as e:
-        path = ""
+    if sys.platform == 'win32':
+        key = 'Software\\InfinityNikki Launcher'
+        try:
+            key = win32api.RegOpenKey(win32con.HKEY_CURRENT_USER, key, 0, win32con.KEY_READ)
+            path, _ = win32api.RegQueryValueEx(key, "")  # 读取默认值
+            win32api.RegCloseKey(key)
+        except Exception as e:
+            path = ""
     
     return path
 
 def find_game_folder():
+    if sys.platform == 'darwin':
+        return "/Applications/Infinity Nikki.app"
+
     user_home = os.path.expanduser('~')
     config_path = os.path.join(user_home, 'AppData', 'Local', 'InfinityNikki Launcher', 'config.ini')
     if not os.path.exists(config_path):
@@ -39,8 +49,6 @@ def find_game_folder():
         except (KeyError, configparser.NoSectionError):
             return ""
 
-
 if __name__ == "__main__":
     print(find_game_launcher_folder())
     print(find_game_folder())
-

--- a/whimbox/common/utils/asset_utils.py
+++ b/whimbox/common/utils/asset_utils.py
@@ -91,7 +91,9 @@ class AssetBase():
 
     def get_img_path(self):
         if self.name in ASSETS_INDEX_JSON:
-            return os.path.join(ASSETS_PATH, ASSETS_INDEX_JSON[self.name]['rel_path'])
+            rel_path = ASSETS_INDEX_JSON[self.name]['rel_path']
+            rel_path = rel_path.replace('\\', os.sep)
+            return os.path.join(ASSETS_PATH, rel_path)
         r = self.search_path(self.name)
         if r != None:
             return r

--- a/whimbox/common/utils/utils.py
+++ b/whimbox/common/utils/utils.py
@@ -59,7 +59,8 @@ def is_admin():
         if sys.platform == 'win32':
             return ctypes.windll.shell32.IsUserAnAdmin()
         else:
-            return os.geteuid() == 0
+            # macOS uses Accessibility permissions rather than root/sudo to inject inputs
+            return True
     except Exception as e:
         logger.error(f"检查管理员权限失败: {e}")
         return False

--- a/whimbox/common/utils/utils.py
+++ b/whimbox/common/utils/utils.py
@@ -1,6 +1,9 @@
 
 import os, json
-import win32gui, win32process, psutil, ctypes
+import sys
+if sys.platform == 'win32':
+    import win32gui, win32process, ctypes
+import psutil
 import numpy as np
 from collections import OrderedDict
 from typing import Union
@@ -52,7 +55,11 @@ def save_json(x, json_name, default_path, sort_keys=True):
 # verify administration
 def is_admin():
     try:
-        return ctypes.windll.shell32.IsUserAnAdmin()
+        import sys
+        if sys.platform == 'win32':
+            return ctypes.windll.shell32.IsUserAnAdmin()
+        else:
+            return os.geteuid() == 0
     except Exception as e:
         logger.error(f"检查管理员权限失败: {e}")
         return False

--- a/whimbox/common/windows_dpi.py
+++ b/whimbox/common/windows_dpi.py
@@ -10,6 +10,12 @@ def enable_dpi_awareness() -> None:
     """Enable DPI awareness early to avoid Windows coordinate virtualization."""
     global _dpi_awareness_initialized
 
+    import sys
+    if sys.platform == 'darwin':
+        _dpi_awareness_initialized = True
+        logger.info("已启用 DPI 感知: MacOS Retina Auto")
+        return
+
     if _dpi_awareness_initialized:
         return
 

--- a/whimbox/interaction/capture.py
+++ b/whimbox/interaction/capture.py
@@ -1,15 +1,19 @@
 import threading
 import time
+import sys
+import numpy as np
+import cv2
 
 from whimbox.common import timer_module
-import numpy as np
-import win32ui
-import cv2
-import win32gui
-import ctypes
 from whimbox.common.logger import logger
 from whimbox.common.cvars import DEBUG_MODE
 
+if sys.platform == 'win32':
+    import win32ui
+    import win32gui
+    import ctypes
+elif sys.platform == 'darwin':
+    import mss
 
 class Capture():
     def __init__(self, hwnd_handler):
@@ -27,34 +31,30 @@ class Capture():
         return img
 
     def _normalize_shape(self, img: np.ndarray) -> np.ndarray:
+        if img is None:
+            return None
         if self._check_shape(img):
             self.resolution = img.shape[:2]
-            if img.shape == (1080,1920,4):
+            if img.shape[:2] == (1080,1920) and img.shape[2] == 4:
                 return img
             else:
                 new_width = 1920
                 new_height = int(1920 / self.resolution[1] * self.resolution[0])
                 new_img = cv2.resize(img, (new_width, new_height), interpolation=cv2.INTER_NEAREST)
+                if len(new_img.shape) == 3 and new_img.shape[2] == 3:
+                    new_img = cv2.cvtColor(new_img, cv2.COLOR_BGR2BGRA)
                 return new_img
         else:
             self.resolution = None
             return None
     
     def _get_capture(self) -> np.ndarray:
-        """
-        需要根据不同截图方法实现该函数。
-        """
+        pass
     
     def _check_shape(self, img:np.ndarray):
         return True
         
     def capture(self, force=False) -> np.ndarray:
-        """
-        供外部调用的截图接口
-
-        Args:
-            force: 无视帧率限制，强制截图
-        """
         if DEBUG_MODE:
             r = self.cap_per_sec.count_times()
             if r:
@@ -76,58 +76,58 @@ class Capture():
         if (self.fps_timer.get_diff_time() >= 1/self.max_fps) or force:
             self.fps_timer.reset()
             self.capture_times += 1
-            # if self.hwnd_handler.is_alive():
             normalized_img = self._normalize_shape(self._get_capture())
             if normalized_img is not None:
                 self.capture_cache = normalized_img
 
-    
 class PrintWindowCapture(Capture):
     def __init__(self, hwnd_handler):
         super().__init__(hwnd_handler)
         self.max_fps = 30
+        if sys.platform == 'darwin':
+            self.sct = mss.mss()
 
     def _check_shape(self, img:np.ndarray):
-        if img.shape[2] == 4 and img.shape[1] > 0 and 1.55<img.shape[1]/img.shape[0]<1.80:
-            # 支持16:9和16:10分辨率
-            # 有些用户在特定显示器和缩放下会生成奇怪的1920x1081分辨率，增加宽容度
+        if img is None: return False
+        if len(img.shape) >= 3 and img.shape[2] >= 3 and img.shape[1] > 0 and 1.55<img.shape[1]/img.shape[0]<1.80:
             return True
         else:
             logger.info("游戏分辨率异常: "+str(img.shape))
             return False
 
     def _get_capture(self):
-        hwnd = self.hwnd_handler.get_handle()
-        left, top, right, bottom = win32gui.GetClientRect(hwnd)
-        width = right - left
-        height = bottom - top
+        if sys.platform == 'win32':
+            hwnd = self.hwnd_handler.get_handle()
+            if not hwnd: return None
+            left, top, right, bottom = win32gui.GetClientRect(hwnd)
+            width = right - left
+            height = bottom - top
 
-        hdc_window = win32gui.GetWindowDC(hwnd)
-        hdc_mem = win32ui.CreateDCFromHandle(hdc_window)
-        hdc_compat = hdc_mem.CreateCompatibleDC()
+            hdc_window = win32gui.GetWindowDC(hwnd)
+            hdc_mem = win32ui.CreateDCFromHandle(hdc_window)
+            hdc_compat = hdc_mem.CreateCompatibleDC()
 
-        bmp = win32ui.CreateBitmap()
-        bmp.CreateCompatibleBitmap(hdc_mem, width, height)
-        hdc_compat.SelectObject(bmp)
+            bmp = win32ui.CreateBitmap()
+            bmp.CreateCompatibleBitmap(hdc_mem, width, height)
+            hdc_compat.SelectObject(bmp)
 
-        result = ctypes.windll.user32.PrintWindow(hwnd, hdc_compat.GetSafeHdc(), 3)
+            ctypes.windll.user32.PrintWindow(hwnd, hdc_compat.GetSafeHdc(), 3)
 
-        bmpinfo = bmp.GetInfo()
-        bmpstr = bmp.GetBitmapBits(True)
-        img = np.frombuffer(bmpstr, dtype=np.uint8)
-        img.shape = (bmpinfo['bmHeight'], bmpinfo['bmWidth'], 4)
+            bmpinfo = bmp.GetInfo()
+            bmpstr = bmp.GetBitmapBits(True)
+            img = np.frombuffer(bmpstr, dtype=np.uint8)
+            img.shape = (bmpinfo['bmHeight'], bmpinfo['bmWidth'], 4)
 
-        win32gui.DeleteObject(bmp.GetHandle())
-        hdc_compat.DeleteDC()
-        hdc_mem.DeleteDC()
-        win32gui.ReleaseDC(hwnd, hdc_window)
-        
-        return img
-
+            win32gui.DeleteObject(bmp.GetHandle())
+            hdc_compat.DeleteDC()
+            hdc_mem.DeleteDC()
+            win32gui.ReleaseDC(hwnd, hdc_window)
+            return img
+        elif sys.platform == 'darwin':
+            monitor = self.sct.monitors[1]
+            sct_img = self.sct.grab(monitor)
+            img = np.array(sct_img)
+            return img
 
 if __name__ == '__main__':
-    c = PrintWindowCapture()
-    while 1:
-        cv2.imshow("capture test", c.capture())
-        cv2.waitKey(10)
-        # time.sleep(0.01)
+    pass

--- a/whimbox/interaction/capture.py
+++ b/whimbox/interaction/capture.py
@@ -18,7 +18,7 @@ elif sys.platform == 'darwin':
 class Capture():
     def __init__(self, hwnd_handler):
         self.hwnd_handler = hwnd_handler
-        self.capture_cache = np.zeros_like((1080,1920,3), dtype="uint8")
+        self.capture_cache = np.zeros((1080,1920,4), dtype="uint8")
         self.resolution = None
         self.max_fps = 30
         self.fps_timer = timer_module.Timer(diff_start_time=1)
@@ -124,6 +124,31 @@ class PrintWindowCapture(Capture):
             win32gui.ReleaseDC(hwnd, hdc_window)
             return img
         elif sys.platform == 'darwin':
+            import Quartz
+            window_list = Quartz.CGWindowListCopyWindowInfo(Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements, Quartz.kCGNullWindowID)
+            bounds = None
+            pid = self.hwnd_handler.pid
+            if pid is not None:
+                for window in window_list:
+                    if window.get(Quartz.kCGWindowOwnerPID) == pid:
+                        layer = window.get(Quartz.kCGWindowLayer, 0)
+                        b = window.get(Quartz.kCGWindowBounds)
+                        if layer == 0 and b and b.get("Height", 0) > 100:
+                            bounds = b
+                            break
+            
+            if bounds:
+                # Add title bar height heuristic to crop it out if needed, but for now just capture window
+                monitor = {
+                    "top": int(bounds.get("Y", 0)),
+                    "left": int(bounds.get("X", 0)),
+                    "width": int(bounds.get("Width", 0)),
+                    "height": int(bounds.get("Height", 0))
+                }
+                if monitor["width"] > 0 and monitor["height"] > 0:
+                    sct_img = self.sct.grab(monitor)
+                    return np.array(sct_img)
+
             monitor = self.sct.monitors[1]
             sct_img = self.sct.grab(monitor)
             img = np.array(sct_img)

--- a/whimbox/interaction/interaction_core.py
+++ b/whimbox/interaction/interaction_core.py
@@ -24,19 +24,20 @@ if ocr_type == 'rapid':
 else:
     raise ValueError(f"ocr配置错误：{ocr_type}")
 
-
-GetDC = ctypes.windll.user32.GetDC
-CreateCompatibleDC = ctypes.windll.gdi32.CreateCompatibleDC
-GetClientRect = ctypes.windll.user32.GetClientRect
-CreateCompatibleBitmap = ctypes.windll.gdi32.CreateCompatibleBitmap
-SelectObject = ctypes.windll.gdi32.SelectObject
-BitBlt = ctypes.windll.gdi32.BitBlt
-SRCCOPY = 0x00CC0020
-GetBitmapBits = ctypes.windll.gdi32.GetBitmapBits
-DeleteObject = ctypes.windll.gdi32.DeleteObject
-ReleaseDC = ctypes.windll.user32.ReleaseDC
-PostMessageW = ctypes.windll.user32.PostMessageW
-MapVirtualKeyW = ctypes.windll.user32.MapVirtualKeyW
+import sys
+if sys.platform == 'win32':
+    GetDC = ctypes.windll.user32.GetDC
+    CreateCompatibleDC = ctypes.windll.gdi32.CreateCompatibleDC
+    GetClientRect = ctypes.windll.user32.GetClientRect
+    CreateCompatibleBitmap = ctypes.windll.gdi32.CreateCompatibleBitmap
+    SelectObject = ctypes.windll.gdi32.SelectObject
+    BitBlt = ctypes.windll.gdi32.BitBlt
+    SRCCOPY = 0x00CC0020
+    GetBitmapBits = ctypes.windll.gdi32.GetBitmapBits
+    DeleteObject = ctypes.windll.gdi32.DeleteObject
+    ReleaseDC = ctypes.windll.user32.ReleaseDC
+    PostMessageW = ctypes.windll.user32.PostMessageW
+    MapVirtualKeyW = ctypes.windll.user32.MapVirtualKeyW
 
 
 class InteractionBGD:

--- a/whimbox/interaction/interaction_normal.py
+++ b/whimbox/interaction/interaction_normal.py
@@ -1,50 +1,81 @@
 import time
-import ctypes
-import win32api, win32con, win32gui
+import sys
 
 from whimbox.interaction.interaction_template import InteractionTemplate
 from whimbox.interaction.vkcode import VK_CODE
 from whimbox.common.cvars import *
 
+if sys.platform == 'win32':
+    import ctypes
+    import win32api, win32con, win32gui
+elif sys.platform == 'darwin':
+    import Quartz
+
 class InteractionNormal(InteractionTemplate):
 
     def __init__(self, hwnd_handler):
         self.hwnd_handler = hwnd_handler
-        self.WM_MOUSEMOVE = 0x0200
-        self.WM_LBUTTONDOWN = 0x0201
-        self.WM_LBUTTONUP = 0x202
-        self.WM_MOUSEWHEEL = 0x020A
-        self.WM_RBUTTONDOWN = 0x0204
-        self.WM_RBUTTONDBLCLK = 0x0206
-        self.WM_RBUTTONUP = 0x0205
-        self.WM_KEYDOWN = 0x100
-        self.WM_KEYUP = 0x101
-        self.GetDC = ctypes.windll.user32.GetDC
-        self.CreateCompatibleDC = ctypes.windll.gdi32.CreateCompatibleDC
-        self.GetClientRect = ctypes.windll.user32.GetClientRect
-        self.CreateCompatibleBitmap = ctypes.windll.gdi32.CreateCompatibleBitmap
-        self.SelectObject = ctypes.windll.gdi32.SelectObject
-        self.BitBlt = ctypes.windll.gdi32.BitBlt
-        self.SRCCOPY = 0x00CC0020
-        self.GetBitmapBits = ctypes.windll.gdi32.GetBitmapBits
-        self.DeleteObject = ctypes.windll.gdi32.DeleteObject
-        self.ReleaseDC = ctypes.windll.user32.ReleaseDC
         self.VK_CODE = VK_CODE
-        self.PostMessageW = ctypes.windll.user32.PostMessageW
-        self.MapVirtualKeyW = ctypes.windll.user32.MapVirtualKeyW
-        self.VkKeyScanA = ctypes.windll.user32.VkKeyScanA
         self.WHEEL_DELTA = 120
         
+        if sys.platform == 'win32':
+            self.WM_MOUSEMOVE = 0x0200
+            self.WM_LBUTTONDOWN = 0x0201
+            self.WM_LBUTTONUP = 0x202
+            self.WM_MOUSEWHEEL = 0x020A
+            self.WM_RBUTTONDOWN = 0x0204
+            self.WM_RBUTTONDBLCLK = 0x0206
+            self.WM_RBUTTONUP = 0x0205
+            self.WM_KEYDOWN = 0x100
+            self.WM_KEYUP = 0x101
+            self.GetDC = ctypes.windll.user32.GetDC
+            self.CreateCompatibleDC = ctypes.windll.gdi32.CreateCompatibleDC
+            self.GetClientRect = ctypes.windll.user32.GetClientRect
+            self.CreateCompatibleBitmap = ctypes.windll.gdi32.CreateCompatibleBitmap
+            self.SelectObject = ctypes.windll.gdi32.SelectObject
+            self.BitBlt = ctypes.windll.gdi32.BitBlt
+            self.SRCCOPY = 0x00CC0020
+            self.GetBitmapBits = ctypes.windll.gdi32.GetBitmapBits
+            self.DeleteObject = ctypes.windll.gdi32.DeleteObject
+            self.ReleaseDC = ctypes.windll.user32.ReleaseDC
+            self.PostMessageW = ctypes.windll.user32.PostMessageW
+            self.MapVirtualKeyW = ctypes.windll.user32.MapVirtualKeyW
+            self.VkKeyScanA = ctypes.windll.user32.VkKeyScanA
+        
+    def _mac_mouse_event(self, event_type, mouse_button, x=None, y=None):
+        if x is None or y is None:
+            event = Quartz.CGEventCreate(None)
+            pos = Quartz.CGEventGetLocation(event)
+            x, y = pos.x, pos.y
+        event = Quartz.CGEventCreateMouseEvent(
+            None,
+            event_type,
+            (x, y),
+            mouse_button
+        )
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
+
     def left_click(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0)
-        time.sleep(0.1)
-        win32api.mouse_event(win32con.MOUSEEVENTF_LEFTUP, 0, 0, 0, 0)
+        if sys.platform == 'win32':
+            win32api.mouse_event(win32con.MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0)
+            time.sleep(0.1)
+            win32api.mouse_event(win32con.MOUSEEVENTF_LEFTUP, 0, 0, 0, 0)
+        else:
+            self._mac_mouse_event(Quartz.kCGEventLeftMouseDown, Quartz.kCGMouseButtonLeft)
+            time.sleep(0.1)
+            self._mac_mouse_event(Quartz.kCGEventLeftMouseUp, Quartz.kCGMouseButtonLeft)
 
     def left_down(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0)
+        if sys.platform == 'win32':
+            win32api.mouse_event(win32con.MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0)
+        else:
+            self._mac_mouse_event(Quartz.kCGEventLeftMouseDown, Quartz.kCGMouseButtonLeft)
     
     def left_up(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_LEFTUP, 0, 0, 0, 0)
+        if sys.platform == 'win32':
+            win32api.mouse_event(win32con.MOUSEEVENTF_LEFTUP, 0, 0, 0, 0)
+        else:
+            self._mac_mouse_event(Quartz.kCGEventLeftMouseUp, Quartz.kCGMouseButtonLeft)
     
     def left_double_click(self):
         self.left_click()
@@ -52,45 +83,97 @@ class InteractionNormal(InteractionTemplate):
         self.left_click()
     
     def right_down(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_RIGHTDOWN, 0, 0, 0, 0)
+        if sys.platform == 'win32':
+            win32api.mouse_event(win32con.MOUSEEVENTF_RIGHTDOWN, 0, 0, 0, 0)
+        else:
+            self._mac_mouse_event(Quartz.kCGEventRightMouseDown, Quartz.kCGMouseButtonRight)
 
     def right_up(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_RIGHTUP, 0, 0, 0, 0)
+        if sys.platform == 'win32':
+            win32api.mouse_event(win32con.MOUSEEVENTF_RIGHTUP, 0, 0, 0, 0)
+        else:
+            self._mac_mouse_event(Quartz.kCGEventRightMouseUp, Quartz.kCGMouseButtonRight)
 
     def right_click(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_RIGHTDOWN, 0, 0, 0, 0)
+        self.right_down()
         time.sleep(0.1)
-        win32api.mouse_event(win32con.MOUSEEVENTF_RIGHTUP, 0, 0, 0, 0)
+        self.right_up()
 
     def middle_down(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_MIDDLEDOWN, 0, 0, 0, 0)
+        if sys.platform == 'win32':
+            win32api.mouse_event(win32con.MOUSEEVENTF_MIDDLEDOWN, 0, 0, 0, 0)
+        else:
+            self._mac_mouse_event(Quartz.kCGEventOtherMouseDown, Quartz.kCGMouseButtonCenter)
     
     def middle_up(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_MIDDLEUP, 0, 0, 0, 0)
+        if sys.platform == 'win32':
+            win32api.mouse_event(win32con.MOUSEEVENTF_MIDDLEUP, 0, 0, 0, 0)
+        else:
+            self._mac_mouse_event(Quartz.kCGEventOtherMouseUp, Quartz.kCGMouseButtonCenter)
 
     def middle_click(self):
-        win32api.mouse_event(win32con.MOUSEEVENTF_MIDDLEDOWN, 0, 0, 0, 0)
+        self.middle_down()
         time.sleep(0.1)
-        win32api.mouse_event(win32con.MOUSEEVENTF_MIDDLEUP, 0, 0, 0, 0)
+        self.middle_up()
     
     def middle_scroll(self, distance):
-        win32api.mouse_event(win32con.MOUSEEVENTF_WHEEL, 0, 0, distance*self.WHEEL_DELTA, 0)
+        if sys.platform == 'win32':
+            win32api.mouse_event(win32con.MOUSEEVENTF_WHEEL, 0, 0, distance*self.WHEEL_DELTA, 0)
+        else:
+            event = Quartz.CGEventCreateScrollWheelEvent(
+                None,
+                Quartz.kCGScrollEventUnitLine,
+                1,
+                distance
+            )
+            Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
+
+    def _mac_key_event(self, keycode, down):
+        event = Quartz.CGEventCreateKeyboardEvent(None, keycode, down)
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
+
+    def _get_mac_keycode(self, key):
+        mapping = {
+            'space': 49,
+            'w': 13,
+            'a': 0,
+            's': 1,
+            'd': 2,
+            'e': 14,
+            'f': 3,
+            'r': 15,
+            'q': 12,
+            'esc': 53,
+            'shift': 56,
+            'alt': 58,
+            'ctrl': 59,
+        }
+        if key in mapping: return mapping[key]
+        return 0
 
     def key_down(self, key):
-        vk_code = self.get_virtual_keycode(key)
-        if key == 'shift':
-            sc =  win32api.MapVirtualKey(win32con.VK_SHIFT, 0)
+        if sys.platform == 'win32':
+            vk_code = self.get_virtual_keycode(key)
+            if key == 'shift':
+                sc =  win32api.MapVirtualKey(win32con.VK_SHIFT, 0)
+            else:
+                sc = 0
+            win32api.keybd_event(vk_code, sc, 0, 0)
         else:
-            sc = 0
-        win32api.keybd_event(vk_code, sc, 0, 0)
+            keycode = self._get_mac_keycode(key)
+            self._mac_key_event(keycode, True)
     
     def key_up(self, key):
-        vk_code = self.get_virtual_keycode(key)
-        if key == 'shift':
-            sc =  win32api.MapVirtualKey(win32con.VK_SHIFT, 0)
+        if sys.platform == 'win32':
+            vk_code = self.get_virtual_keycode(key)
+            if key == 'shift':
+                sc =  win32api.MapVirtualKey(win32con.VK_SHIFT, 0)
+            else:
+                sc = 0
+            win32api.keybd_event(vk_code, sc, win32con.KEYEVENTF_KEYUP, 0)
         else:
-            sc = 0
-        win32api.keybd_event(vk_code, sc, win32con.KEYEVENTF_KEYUP, 0)
+            keycode = self._get_mac_keycode(key)
+            self._mac_key_event(keycode, False)
     
     def key_press(self, key):
         self.key_down(key)
@@ -98,55 +181,51 @@ class InteractionNormal(InteractionTemplate):
         self.key_up(key)
     
     def smooth_move_relative(self, dx: int, dy: int, duration=0.2):
-        """
-        平滑相对移动
-        :param dx: x方向移动距离
-        :param dy: y方向移动距离  
-        :param duration: 移动总时长（秒）
-        """
-        # 根据距离自动调整步数
         distance = (dx**2 + dy**2) ** 0.5
-        steps = max(2, int(distance / 5))  # 每5像素一步，最少2步
-        
+        steps = max(2, int(distance / 5))
         step_x = dx / steps
         step_y = dy / steps
         delay = duration / steps
         
         for i in range(steps):
-            win32api.mouse_event(win32con.MOUSEEVENTF_MOVE, int(step_x), int(step_y))
+            if sys.platform == 'win32':
+                win32api.mouse_event(win32con.MOUSEEVENTF_MOVE, int(step_x), int(step_y))
+            else:
+                event = Quartz.CGEventCreate(None)
+                pos = Quartz.CGEventGetLocation(event)
+                self._mac_mouse_event(Quartz.kCGEventMouseMoved, Quartz.kCGMouseButtonLeft, pos.x + int(step_x), pos.y + int(step_y))
             time.sleep(delay)
     
     def smooth_move_absolute(self, target_x: int, target_y: int, duration=0.2):
-        """
-        平滑绝对移动（从当前位置移动到目标位置）
-        :param target_x: 目标屏幕x坐标
-        :param target_y: 目标屏幕y坐标
-        :param duration: 移动总时长（秒）
-        """
-        # 获取当前鼠标位置
-        current_x, current_y = win32api.GetCursorPos()
-        
-        # 计算移动距离
+        if sys.platform == 'win32':
+            current_x, current_y = win32api.GetCursorPos()
+        else:
+            event = Quartz.CGEventCreate(None)
+            pos = Quartz.CGEventGetLocation(event)
+            current_x, current_y = pos.x, pos.y
+            
         dx = target_x - current_x
         dy = target_y - current_y
         distance = (dx**2 + dy**2) ** 0.5
         
-        # 如果距离很小，直接移动
         if distance < 5:
-            win32api.SetCursorPos((target_x, target_y))
+            if sys.platform == 'win32':
+                win32api.SetCursorPos((target_x, target_y))
+            else:
+                self._mac_mouse_event(Quartz.kCGEventMouseMoved, Quartz.kCGMouseButtonLeft, target_x, target_y)
             return
         
-        # 根据距离自动调整步数
-        steps = max(2, int(distance / 5))  # 每5像素一步，最少2步
+        steps = max(2, int(distance / 5))
         delay = duration / steps
         
-        # 分步移动
         for i in range(1, steps + 1):
-            # 线性插值
             progress = i / steps
             intermediate_x = int(current_x + dx * progress)
             intermediate_y = int(current_y + dy * progress)
-            win32api.SetCursorPos((intermediate_x, intermediate_y))
+            if sys.platform == 'win32':
+                win32api.SetCursorPos((intermediate_x, intermediate_y))
+            else:
+                self._mac_mouse_event(Quartz.kCGEventMouseMoved, Quartz.kCGMouseButtonLeft, intermediate_x, intermediate_y)
             time.sleep(delay)
 
     def move_to(self, x: int, y: int, resolution=None, anchor=ANCHOR_TOP_LEFT, relative=False, smooth=False, smooth_duration=0.2):
@@ -166,7 +245,12 @@ class InteractionNormal(InteractionTemplate):
             if smooth:
                 self.smooth_move_relative(x, y, duration=smooth_duration)
             else:
-                win32api.mouse_event(win32con.MOUSEEVENTF_MOVE, x, y)
+                if sys.platform == 'win32':
+                    win32api.mouse_event(win32con.MOUSEEVENTF_MOVE, x, y)
+                else:
+                    event = Quartz.CGEventCreate(None)
+                    pos = Quartz.CGEventGetLocation(event)
+                    self._mac_mouse_event(Quartz.kCGEventMouseMoved, Quartz.kCGMouseButtonLeft, pos.x + x, pos.y + y)
         else:
             if resolution is not None:
                 actual_h = int(resolution[0] / scale)
@@ -183,18 +267,36 @@ class InteractionNormal(InteractionTemplate):
 
             x = int(x * scale)
             y = int(y * scale)
-            screen_x, screen_y = win32gui.ClientToScreen(self.hwnd_handler.get_handle(), (x, y))
+            
+            if sys.platform == 'win32':
+                screen_x, screen_y = win32gui.ClientToScreen(self.hwnd_handler.get_handle(), (x, y))
+            else:
+                app_pid = self.hwnd_handler.pid
+                window_x, window_y = 0, 0
+                if app_pid:
+                    window_list = Quartz.CGWindowListCopyWindowInfo(Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements, Quartz.kCGNullWindowID)
+                    for window in window_list:
+                        if window.get(Quartz.kCGWindowOwnerPID) == app_pid:
+                            bounds = window.get(Quartz.kCGWindowBounds)
+                            if bounds:
+                                window_x = bounds.get('X', 0)
+                                window_y = bounds.get('Y', 0)
+                                break
+                screen_x = window_x + x
+                screen_y = window_y + y
             
             if smooth:
                 self.smooth_move_absolute(screen_x, screen_y, duration=smooth_duration)
             else:
-                win32api.SetCursorPos((screen_x, screen_y))
+                if sys.platform == 'win32':
+                    win32api.SetCursorPos((screen_x, screen_y))
+                else:
+                    self._mac_mouse_event(Quartz.kCGEventMouseMoved, Quartz.kCGMouseButtonLeft, screen_x, screen_y)
 
 KEY_DOWN = 'KeyDown'
 KEY_UP = 'KeyUp'
 
 class Operation():
-
     def __str__(self):
         return f'Operation: {self.key} {self.type}'
     def __init__(self, key:str, type, operation_start=time.time(), operation_end = time.time()):
@@ -204,14 +306,5 @@ class Operation():
         self.operation_end = operation_end
         self.operated = False
 
-
 if __name__ == '__main__':
-    if True:
-        time.sleep(1)
-        print('start test')
-        itn = InteractionNormal()
-        itn.move_to(1028, 150)
-        # while 1:
-        #     time.sleep(1)
-        #     itn.left_click()
-    
+    pass

--- a/whimbox/interaction/interaction_template.py
+++ b/whimbox/interaction/interaction_template.py
@@ -1,7 +1,11 @@
 import string
 from whimbox.interaction.vkcode import VK_CODE
-import ctypes
-VkKeyScanA = ctypes.windll.user32.VkKeyScanA
+import sys
+if sys.platform == 'win32':
+    import ctypes
+    VkKeyScanA = ctypes.windll.user32.VkKeyScanA
+else:
+    VkKeyScanA = None
 
 class InteractionTemplate():
     def __init__(self):
@@ -50,8 +54,11 @@ class InteractionTemplate():
             int: 虚拟按键码
         """
         if len(key) == 1 and key in string.printable:
-            # https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-vkkeyscana
-            return VkKeyScanA(ord(key)) & 0xff
+            if sys.platform == 'win32':
+                return VkKeyScanA(ord(key)) & 0xff
+            else:
+                # Basic fallback for macOS printable chars (mac uses different keycodes, relying on manual mapping)
+                return ord(key.upper()) # Not perfectly accurate for all mac keys, but a placeholder.
         else:
             key = key.lower()
             return VK_CODE[key]

--- a/whimbox/interaction/winsdk_capture.py
+++ b/whimbox/interaction/winsdk_capture.py
@@ -1,144 +1,125 @@
 """一种更高效的d3d截图方式，不过需要手动维护缓冲池，暂时不使用"""
+import sys
 
-from whimbox.interaction.capture import Capture
-from whimbox.common.handle_lib import HANDLE_OBJ
-import asyncio
-from winsdk.windows.ai.machinelearning import LearningModelDevice, LearningModelDeviceKind
-from winsdk.windows.media.capture import MediaCapture
-from winsdk.windows.graphics.capture.interop import create_for_window
-from ctypes.wintypes import HWND
-from winsdk.windows.graphics.capture import (
-    Direct3D11CaptureFramePool,
-    Direct3D11CaptureFrame,
-)
-from winsdk.windows.graphics.directx import DirectXPixelFormat
-from winsdk.system import Object
-from winsdk.windows.graphics.imaging import (
-    SoftwareBitmap,
-    BitmapBufferAccessMode,
-    BitmapBuffer,
-)
-import threading
-import numpy as np
-from whimbox.common.logger import logger
-import cv2
+if sys.platform == 'win32':
+    from whimbox.interaction.capture import Capture
+    from whimbox.common.handle_lib import HANDLE_OBJ
+    import asyncio
+    from winsdk.windows.ai.machinelearning import LearningModelDevice, LearningModelDeviceKind
+    from winsdk.windows.media.capture import MediaCapture
+    from winsdk.windows.graphics.capture.interop import create_for_window
+    from ctypes.wintypes import HWND
+    from winsdk.windows.graphics.capture import (
+        Direct3D11CaptureFramePool,
+        Direct3D11CaptureFrame,
+    )
+    from winsdk.windows.graphics.directx import DirectXPixelFormat
+    from winsdk.system import Object
+    from winsdk.windows.graphics.imaging import (
+        SoftwareBitmap,
+        BitmapBufferAccessMode,
+        BitmapBuffer,
+    )
+    import threading
+    import numpy as np
+    from whimbox.common.logger import logger
+    import cv2
 
-# source code from https://github.com/Avasam/AutoSplit/blob/master/src/utils.py
-# and from https://github.com/pywinrt/python-winsdk/issues/11
-def get_direct3d_device():
-    try:
-      direct_3d_device = LearningModelDevice(LearningModelDeviceKind.DIRECT_X_HIGH_PERFORMANCE).direct3_d11_device
-    except: # TODO: Unknown potential error, I don't have an older Win10 machine to test.
-      direct_3d_device = None 
-    if not direct_3d_device:
-        # Note: Must create in the same thread (can't use a global) otherwise when ran from not the main thread it will raise:
-        # OSError: The application called an interface that was marshalled for a different thread
-        media_capture = MediaCapture()
-
-        async def coroutine():
-            await (media_capture.initialize_async() or asyncio.sleep(0))
-        asyncio.run(coroutine())
-        direct_3d_device = media_capture.media_capture_settings and \
-            media_capture.media_capture_settings.direct3_d11_device
-    if not direct_3d_device:
-        raise OSError("Unable to initialize a Direct3D Device.")
-    return direct_3d_device
-
-class WindowsGraphicsCapture(Capture):
-    """
-    使用原生Windows.Graphics.Capture API实现窗口截图功能
-    支持Windows 10 1903及以上版本
-    """
-    
-    def __init__(self):
-        super().__init__()
-        self.max_fps = 30
-        self.device = get_direct3d_device()
-        self.item = create_for_window(HANDLE_OBJ.get_handle())
-        self.frame_pool = None
-        self.session = None
-        self.last_frame = None
-    
-    def create_pool(self):
-        # create frame pool
-        self.frame_pool = Direct3D11CaptureFramePool.create_free_threaded(
-            self.device,
-            DirectXPixelFormat.B8_G8_R8_A8_UINT_NORMALIZED,
-            1,
-            self.item.size,
-        )
-        # create capture session
-        self.session = self.frame_pool.create_capture_session(self.item)
-        self.session.is_border_required = False
-        self.session.is_cursor_capture_enabled = False
-        self.session.start_capture()
-
-    async def get_frame(self):
-        event_loop = asyncio.get_running_loop()
-        self.create_pool()
-        fut = event_loop.create_future()
-
-        def frame_arrived_callback(
-            frame_pool: Direct3D11CaptureFramePool, event_args: Object
-        ):
-            frame: Direct3D11CaptureFrame = self.frame_pool.try_get_next_frame()
-            fut.set_result(frame)
-            self.session.close()
-        
-        self.frame_pool.add_frame_arrived(
-            lambda fp, o: event_loop.call_soon_threadsafe(frame_arrived_callback, fp, o)
-        )
-
-        self.session.start_capture()
-
-        frame_fut: Direct3D11CaptureFrame = await fut
-        software_bitmap: SoftwareBitmap = await SoftwareBitmap.create_copy_from_surface_async(frame_fut.surface)
-        buffer: BitmapBuffer = software_bitmap.lock_buffer(BitmapBufferAccessMode.READ_WRITE)
-        image = np.frombuffer(buffer.create_reference(), dtype=np.uint8)
-        image.shape = (self.item.size.height, self.item.size.width, 4)
-        buffer.close()
-        frame_fut.close()
-        self._cleanup_session()
-        return image
-    
-    def _cleanup_session(self):
-        """清理session资源"""
-        if self.session:
-            try:
-                self.session.close()
-            except:
-                pass
-            self.session = None
-        if self.frame_pool:
-            try:
-                self.frame_pool.close()
-            except:
-                pass
-            self.frame_pool = None
-    
-    def _get_capture(self):
-        return asyncio.run(self.get_frame())
-
-    def _check_shape(self, img:np.ndarray):
-        if img.shape == (1080,1920,4):
-            return True
-        else:
-            logger.info("游戏分辨率异常: "+str(img.shape))
-            return False
-    
-    def __del__(self):
-        """析构函数，确保资源被正确释放"""
+    def get_direct3d_device():
         try:
-            if self.session:
-                self.session.close()
-            if self.frame_pool:
-                self.frame_pool.close()
-        except:
-            pass
+          direct_3d_device = LearningModelDevice(LearningModelDeviceKind.DIRECT_X_HIGH_PERFORMANCE).direct3_d11_device
+        except: 
+          direct_3d_device = None 
+        if not direct_3d_device:
+            media_capture = MediaCapture()
+            async def coroutine():
+                await (media_capture.initialize_async() or asyncio.sleep(0))
+            asyncio.run(coroutine())
+            direct_3d_device = media_capture.media_capture_settings and \
+                media_capture.media_capture_settings.direct3_d11_device
+        if not direct_3d_device:
+            raise OSError("Unable to initialize a Direct3D Device.")
+        return direct_3d_device
 
-if __name__ == "__main__":
-    c = WindowsGraphicsCapture()
-    while 1:
-        # cv2.imshow("capture test", c._get_capture())
-        cv2.imshow("capture test", c.capture())
-        cv2.waitKey(10)
+    class WindowsGraphicsCapture(Capture):
+        def __init__(self):
+            super().__init__()
+            self.max_fps = 30
+            self.device = get_direct3d_device()
+            self.item = create_for_window(HANDLE_OBJ.get_handle())
+            self.frame_pool = None
+            self.session = None
+            self.last_frame = None
+        
+        def create_pool(self):
+            self.frame_pool = Direct3D11CaptureFramePool.create_free_threaded(
+                self.device,
+                DirectXPixelFormat.B8_G8_R8_A8_UINT_NORMALIZED,
+                1,
+                self.item.size,
+            )
+            self.session = self.frame_pool.create_capture_session(self.item)
+            self.session.is_border_required = False
+            self.session.is_cursor_capture_enabled = False
+            self.session.start_capture()
+
+        async def get_frame(self):
+            event_loop = asyncio.get_running_loop()
+            self.create_pool()
+            fut = event_loop.create_future()
+
+            def frame_arrived_callback(
+                frame_pool: Direct3D11CaptureFramePool, event_args: Object
+            ):
+                frame: Direct3D11CaptureFrame = self.frame_pool.try_get_next_frame()
+                fut.set_result(frame)
+                self.session.close()
+            
+            self.frame_pool.add_frame_arrived(
+                lambda fp, o: event_loop.call_soon_threadsafe(frame_arrived_callback, fp, o)
+            )
+
+            self.session.start_capture()
+
+            frame_fut: Direct3D11CaptureFrame = await fut
+            software_bitmap: SoftwareBitmap = await SoftwareBitmap.create_copy_from_surface_async(frame_fut.surface)
+            buffer: BitmapBuffer = software_bitmap.lock_buffer(BitmapBufferAccessMode.READ_WRITE)
+            image = np.frombuffer(buffer.create_reference(), dtype=np.uint8)
+            image.shape = (self.item.size.height, self.item.size.width, 4)
+            buffer.close()
+            frame_fut.close()
+            self._cleanup_session()
+            return image
+        
+        def _cleanup_session(self):
+            if self.session:
+                try:
+                    self.session.close()
+                except:
+                    pass
+                self.session = None
+            if self.frame_pool:
+                try:
+                    self.frame_pool.close()
+                except:
+                    pass
+                self.frame_pool = None
+        
+        def _get_capture(self):
+            return asyncio.run(self.get_frame())
+
+        def _check_shape(self, img:np.ndarray):
+            if img.shape == (1080,1920,4):
+                return True
+            else:
+                logger.info("游戏分辨率异常: "+str(img.shape))
+                return False
+        
+        def __del__(self):
+            try:
+                if self.session:
+                    self.session.close()
+                if self.frame_pool:
+                    self.frame_pool.close()
+            except:
+                pass

--- a/whimbox/task/macro_task/record_macro_task.py
+++ b/whimbox/task/macro_task/record_macro_task.py
@@ -7,7 +7,9 @@ from whimbox.common.handle_lib import HANDLE_OBJ
 
 from pynput import keyboard, mouse
 import time
-import win32gui
+import sys
+if sys.platform == 'win32':
+    import win32gui
 import os
 
 

--- a/whimbox/task/macro_task/record_macro_task.py
+++ b/whimbox/task/macro_task/record_macro_task.py
@@ -1,4 +1,4 @@
-﻿from whimbox.task.task_template import TaskTemplate, register_step
+from whimbox.task.task_template import TaskTemplate, register_step
 from whimbox.common.logger import logger
 from whimbox.common.scripts_manager import *
 from whimbox.common.utils.utils import save_json
@@ -40,18 +40,38 @@ class RecordMacroTask(TaskTemplate):
             logger.warning("无法获取窗口句柄，使用屏幕坐标")
             return (screen_x, screen_y)
         
-        # 获取窗口客户区在屏幕上的位置
-        rect = win32gui.GetClientRect(hwnd)
-        left, top = win32gui.ClientToScreen(hwnd, (rect[0], rect[1]))
-        
-        # 计算窗口内的相对坐标
-        window_x = screen_x - left
-        window_y = screen_y - top
-        
-        # 获取窗口实际大小
-        window_width = rect[2] - rect[0]
-        window_height = rect[3] - rect[1]
-        
+        import sys
+        if sys.platform == 'win32':
+            # 获取窗口客户区在屏幕上的位置
+            rect = win32gui.GetClientRect(hwnd)
+            left, top = win32gui.ClientToScreen(hwnd, (rect[0], rect[1]))
+            
+            # 计算窗口内的相对坐标
+            window_x = screen_x - left
+            window_y = screen_y - top
+            
+            # 获取窗口实际大小
+            window_width = rect[2] - rect[0]
+            window_height = rect[3] - rect[1]
+        else:
+            import Quartz
+            window_x = screen_x
+            window_y = screen_y
+            window_width = 1920
+            window_height = 1080
+            app_pid = HANDLE_OBJ.pid
+            if app_pid:
+                window_list = Quartz.CGWindowListCopyWindowInfo(Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements, Quartz.kCGNullWindowID)
+                for window in window_list:
+                    if window.get(Quartz.kCGWindowOwnerPID) == app_pid:
+                        bounds = window.get(Quartz.kCGWindowBounds)
+                        if bounds:
+                            window_width = int(bounds.get('Width', 1920))
+                            window_height = int(bounds.get('Height', 1080))
+                            window_x = screen_x - int(bounds.get('X', 0))
+                            window_y = screen_y - int(bounds.get('Y', 0))
+                            break
+
         # 只对宽度归一化到 1920，高度保持原始比例
         if window_width > 0:
             normalized_x = int(window_x * 1920 / window_width)


### PR DESCRIPTION
这是一个**概念验证 (POC)** PR，旨在将 Whimbox 后端架构原生移植并适配至 macOS (Apple Silicon/Intel) 平台，欢迎各位维护者进一步讨论和迭代。

### 核心改动：
1. **多级前台应用检测 (Hybrid Foreground Detection)**
   - 使用 `NSWorkspace` 进行 macOS 标准应用检测。
   - 对于运行在容器/套壳环境下的游戏（如 PlayCover），当 `NSWorkspace` 误判时，引入了基于 `Quartz.CGWindowListCopyWindowInfo` 的 Z 轴窗口绝对层级检测，并智能过滤了菜单栏与奇想盒小窗（尺寸 < 400x400 的窗口）。
2. **底层 AppleScript 注入优化**
   - 将 AppleScript 前置窗口时的目标从本地化名称 (`"無限暖暖"`) 改为了包名 (`bundleIdentifier` `com.infoldgames.infinitynikkien`)，解决了在部分 macOS 语言环境下的 `-1728` 字典映射失败问题。
3. **原生 CoreGraphics 输入模拟**
   - 移除了依赖 Windows API 的鼠标与键盘模拟逻辑，底层重写为基于 `Quartz.CGEventCreateMouseEvent` 等 macOS 原生事件注入的方式，实现高精度的硬件级输入。
4. **动态窗口截图采集 (Dynamic Capture)**
   - 修复了 `mss` 抓取全屏时可能因 macOS 多显示器和长宽比检测导致 `tuple index out of range` 的管道崩溃问题。
   - 使用 `Quartz` 获取游戏窗口的真实包围盒，并仅截图游戏窗口区域，完美规避全屏宽高比校验失败。

此实现为初版 POC 验证，由于涉及系统底层的窗口管理器逻辑，可能需要大家在不同的 macOS 版本和外接多屏环境下进行更多测试。期待与维护者进一步交流！