### PR TITLE
ci: 添加自动构建 wheel 工作流

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,0 +1,35 @@
+name: Build Wheel
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12.8'
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build wheel
+        run: python -m build --wheel
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: whimbox-wheel
+          path: dist/*.whl
+
+      - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.whl

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -2,8 +2,11 @@ name: Build Wheel
 
 on:
   push:
+    branches: [main]
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
  ## 概述
  
  添加 GitHub Actions 工作流，自动构建 `whimbox-x.y.z-py3-none-any.whl`。
  
  ## 触发条件
  
  - 推送到 `main` 分支
  - 针对 `main` 的 Pull Request
  - 推送版本标签（如 `2.4.3`）
  - 手动触发（workflow_dispatch）
  
  ## 功能
  
  - 使用 Python 3.12.8 + `python -m build` 构建 wheel
  - 每次运行均可在 Actions 页面下载构建产物
  - 推送版本标签时自动上传至 GitHub Release
  
  ## 收益
  
  - 构建过程标准化、可复现
  - 无需本地手动执行 `build.bat`（暂未删除）
  - 每次提交均可获取可测试的 wheel 文件